### PR TITLE
Set up playground defaults

### DIFF
--- a/overrides.json
+++ b/overrides.json
@@ -1,0 +1,5 @@
+{
+  "jupyterlab-codeium:inline-provider": {
+    "apiKey": "d49954eb-cfba-4992-980f-d8fb37f0e942"
+  }
+}

--- a/overrides.json
+++ b/overrides.json
@@ -1,5 +1,14 @@
 {
   "jupyterlab-codeium:inline-provider": {
     "apiKey": "d49954eb-cfba-4992-980f-d8fb37f0e942"
+  },
+  "@jupyterlab/shortcuts-extension:shortcuts": {
+    "shortcuts": [
+      {
+        "command": "inline-completer:accept",
+        "selector": ".jp-mod-inline-completer-active",
+        "keys": ["Tab"]
+      }
+    ]
   }
 }


### PR DESCRIPTION
So it's easier to try the extension with the demo JupyterLite deployment on GitHub Pages.